### PR TITLE
Update apolloProvider instantiation to match latest method

### DIFF
--- a/quickstart-with-apollo/src/main.js
+++ b/quickstart-with-apollo/src/main.js
@@ -12,12 +12,15 @@ const apolloClient = new ApolloClient({
 })
 
 // Install the vue plugin
-Vue.use(VueApollo, {
-  apolloClient,
+Vue.use(VueApollo)
+
+const apolloProvider = new VueApollo({
+  defaultClient: apolloClient,
 })
 
 // Start the app
 new Vue({
   el: '#app',
+  apolloProvider,
   render: h => h(App)
 })

--- a/subscriptions-with-apollo/src/main.js
+++ b/subscriptions-with-apollo/src/main.js
@@ -32,8 +32,6 @@ const apolloProvider = new VueApollo({
   defaultClient: apolloClient,
 })
 
-const ensureReady = apolloProvider.collect()
-
 // Start the app
 new Vue({
   el: '#app',


### PR DESCRIPTION
Update to how apolloProvider is instantiated to match latest method.

In quickstart, apolloClient needed to be given during a missing instantiation of apolloProvider which is turn is given to the root Vue instance.

In subscriptions, the above was already done but still needed to remove an obsolete  "apolloProvider.collect()" method call which was causing an error.
